### PR TITLE
Fix the problem with passing ref to components that use forwardRef

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -36,7 +36,7 @@ export const useObserver = <T extends HTMLElement>(
   useEffect(() => {
     if (!entry.current) {
       observer.current.observe(ref.current);
-    } else if (options?.triggerOnce) {
+    } else if (options?.triggerOnce && ref.current) {
       observer.current.unobserve(ref.current);
     }
   }, [ref, inView, options]);


### PR DESCRIPTION
If we're passing a ref to a component that is using `forwardRef`, a following error will appear:

`Uncaught TypeError: Failed to execute 'observe' on 'IntersectionObserver': parameter 1 is not of type 'Element'.
`

This PR fixes the error